### PR TITLE
Fix for buffer corruption.

### DIFF
--- a/lib/stream.js
+++ b/lib/stream.js
@@ -90,6 +90,12 @@ var FastCGIStream = module.exports = function(stream) {
 	this.writeRecord = function(requestId, record) {
 		var recordBodyLength = record.getSize();
 		var paddingLength = recordBodyLength % 8; // Align the record to an 8 byte boundary.
+		var fullLength = 8 + recordBodyLength + paddingLength;
+
+		/* Allocate a new buffer, since stream.write() will hold the pointer to the buffer
+		 * until the operation finishes, which may not occur immediately.
+		 */
+		var writeBuffer = new Buffer(fullLength);
 
 		writeBuffer[0] = constants.VERSION;
 		writeBuffer[1] = record.TYPE;
@@ -99,10 +105,9 @@ var FastCGIStream = module.exports = function(stream) {
 		writeBuffer[6] = paddingLength;
 		writeBuffer[7] = 0;
 
-		if(recordBodyLength) record.write(writeBuffer.slice(8, 8 + recordBodyLength + paddingLength));
+		if(recordBodyLength) record.write(writeBuffer.slice(8, fullLength));
 		
-		var buf = writeBuffer.slice(0, 8 + recordBodyLength + paddingLength);
-		return stream.write(buf);
+		return stream.write(writeBuffer);
 	};
 };
 util.inherits(FastCGIStream, events.EventEmitter);

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -5,11 +5,6 @@ var util = require("util"),
 	BufferList = require("bufferlist").BufferList,
 	records = require("./records");
 
-// Given that javascript is single threaded, we can safely allocate a write buffer for all streams, even if there's several at once.
-// This buffer is pre-allocated to the absolute maximum size a FCGI record can be, which is the size of the header, that max size of record body,
-// and the max size of padding.
-var writeBuffer = new Buffer(constants.HEADER_LEN + constants.MAX_CONTENT_SIZE + constants.MAX_PADDING_SIZE);
-
 // Lookup table for FCGI records.
 var fcgiRecords = {};
 fcgiRecords[records.BeginRequest.TYPE] = records.BeginRequest;


### PR DESCRIPTION
When sending lots of data, stream.write() may not write the data immediately, but schedule it for later. The scheduled write request will store a pointer to the buffer passed to write() method, so subsequent calls to writeRecord() will corrupt the data for all pending write requests.

Allocating a new buffer for each write request avoids this problem.
